### PR TITLE
Monstie eggs colour tags

### DIFF
--- a/docs/monsters/barioth.md
+++ b/docs/monsters/barioth.md
@@ -16,4 +16,4 @@ Fire
 ### Egg pattern
 ![image info](../assets/barioth.png)
 
-Egg Tags: 
+Egg Tags: orange,white

--- a/docs/monsters/barroth.md
+++ b/docs/monsters/barroth.md
@@ -16,4 +16,4 @@ Fire
 ### Egg pattern
 ![image info](../assets/barroth.png)
 
-Egg Tags: 
+Egg Tags: brown,orange

--- a/docs/monsters/basarios.md
+++ b/docs/monsters/basarios.md
@@ -16,4 +16,4 @@ Water
 ### Egg pattern
 ![image info](../assets/basarios.png)
 
-Egg Tags: 
+Egg Tags: brown,cream

--- a/docs/monsters/bazelgeuse.md
+++ b/docs/monsters/bazelgeuse.md
@@ -16,4 +16,4 @@ Thunder
 ### Egg pattern
 ![image info](../assets/bazelgeuse.png)
 
-Egg Tags: 
+Egg Tags: black,white

--- a/docs/monsters/black_diablos.md
+++ b/docs/monsters/black_diablos.md
@@ -16,4 +16,4 @@ Ice
 ### Egg pattern
 ![image info](../assets/black_diablos.png)
 
-Egg Tags: 
+Egg Tags: brown

--- a/docs/monsters/black_gravios.md
+++ b/docs/monsters/black_gravios.md
@@ -16,4 +16,4 @@ Water
 ### Egg pattern
 ![image info](../assets/black_gravios.png)
 
-Egg Tags: 
+Egg Tags: orange,grey

--- a/docs/monsters/bloodbath_diablos.md
+++ b/docs/monsters/bloodbath_diablos.md
@@ -16,4 +16,4 @@ Water
 ### Egg pattern
 ![image info](../assets/bloodbath_diablos.png)
 
-Egg Tags: 
+Egg Tags: white,blue

--- a/docs/monsters/blue_yian_kut-ku.md
+++ b/docs/monsters/blue_yian_kut-ku.md
@@ -16,4 +16,4 @@ Water
 ### Egg pattern
 ![image info](../assets/blue_yian_kut-ku.png)
 
-Egg Tags: 
+Egg Tags: blue,yellow

--- a/docs/monsters/boltreaver_astalos.md
+++ b/docs/monsters/boltreaver_astalos.md
@@ -18,4 +18,4 @@ Ice
 ### Egg pattern
 ![image info](../assets/boltreaver_astalos.png)
 
-Egg Tags: 
+Egg Tags: black,green

--- a/docs/monsters/brachydios.md
+++ b/docs/monsters/brachydios.md
@@ -16,4 +16,4 @@ Water
 ### Egg pattern
 ![image info](../assets/brachydios.png)
 
-Egg Tags: 
+Egg Tags: blue,green

--- a/docs/monsters/brute_tigrex.md
+++ b/docs/monsters/brute_tigrex.md
@@ -16,4 +16,4 @@ Water
 ### Egg pattern
 ![image info](../assets/brute_tigrex.png)
 
-Egg Tags: 
+Egg Tags: orange,brown

--- a/docs/monsters/bulldrome.md
+++ b/docs/monsters/bulldrome.md
@@ -16,4 +16,4 @@ Thunder
 ### Egg pattern
 ![image info](../assets/bulldrome.png)
 
-Egg Tags: 
+Egg Tags: brown,cream

--- a/docs/monsters/cephadrome.md
+++ b/docs/monsters/cephadrome.md
@@ -16,4 +16,4 @@ Ice
 ### Egg pattern
 ![image info](../assets/cephadrome.png)
 
-Egg Tags: 
+Egg Tags: brown,orange

--- a/docs/monsters/congalala.md
+++ b/docs/monsters/congalala.md
@@ -16,4 +16,4 @@ Fire
 ### Egg pattern
 ![image info](../assets/congalala.png)
 
-Egg Tags: 
+Egg Tags: pink,green

--- a/docs/monsters/crimson_qurupeco.md
+++ b/docs/monsters/crimson_qurupeco.md
@@ -16,4 +16,4 @@ Ice
 ### Egg pattern
 ![image info](../assets/crimson_qurupeco.png)
 
-Egg Tags: 
+Egg Tags: pink,yellow

--- a/docs/monsters/deviljho.md
+++ b/docs/monsters/deviljho.md
@@ -16,4 +16,4 @@ Dragon
 ### Egg pattern
 ![image info](../assets/deviljho.png)
 
-Egg Tags: 
+Egg Tags: green,red

--- a/docs/monsters/diablos.md
+++ b/docs/monsters/diablos.md
@@ -16,4 +16,4 @@ Ice
 ### Egg pattern
 ![image info](../assets/diablos.png)
 
-Egg Tags: 
+Egg Tags: brown,cream

--- a/docs/monsters/dreadqueen_rathian.md
+++ b/docs/monsters/dreadqueen_rathian.md
@@ -16,4 +16,4 @@ Dragon
 ### Egg pattern
 ![image info](../assets/dreadqueen_rathian.png)
 
-Egg Tags: 
+Egg Tags: green,purple

--- a/docs/monsters/emerald_congalala.md
+++ b/docs/monsters/emerald_congalala.md
@@ -15,4 +15,4 @@ Ice
 ### Egg pattern
 ![image info](../assets/emerald_congalala.png)
 
-Egg Tags: 
+Egg Tags: green,orange

--- a/docs/monsters/fulgur_anjanath.md
+++ b/docs/monsters/fulgur_anjanath.md
@@ -16,4 +16,4 @@ Ice
 ### Egg pattern
 ![image info](../assets/fulgur_anjanath.png)
 
-Egg Tags: 
+Egg Tags: white,orange

--- a/docs/monsters/gammoth.md
+++ b/docs/monsters/gammoth.md
@@ -15,4 +15,4 @@ Fire
 ### Egg pattern
 ![image info](../assets/gammoth.png)
 
-Egg Tags: 
+Egg Tags: blue,red

--- a/docs/monsters/gendrome.md
+++ b/docs/monsters/gendrome.md
@@ -16,4 +16,4 @@ Ice
 ### Egg pattern
 ![image info](../assets/gendrome.png)
 
-Egg Tags: 
+Egg Tags: green,orange

--- a/docs/monsters/glavenus.md
+++ b/docs/monsters/glavenus.md
@@ -17,4 +17,4 @@ Water
 ### Egg pattern
 ![image info](../assets/glavenus.png)
 
-Egg Tags: 
+Egg Tags: blue,red

--- a/docs/monsters/gravios.md
+++ b/docs/monsters/gravios.md
@@ -16,4 +16,4 @@ Water
 ### Egg pattern
 ![image info](../assets/gravios.png)
 
-Egg Tags: 
+Egg Tags: orange,cream

--- a/docs/monsters/great_baggi.md
+++ b/docs/monsters/great_baggi.md
@@ -16,4 +16,4 @@ Fire
 ### Egg pattern
 ![image info](../assets/great_baggi.png)
 
-Egg Tags: 
+Egg Tags: blue,yellow

--- a/docs/monsters/great_jaggi.md
+++ b/docs/monsters/great_jaggi.md
@@ -16,4 +16,4 @@ Fire
 ### Egg pattern
 ![image info](../assets/great_jaggi.png)
 
-Egg Tags: 
+Egg Tags: purple,red

--- a/docs/monsters/green_nargacuga.md
+++ b/docs/monsters/green_nargacuga.md
@@ -16,4 +16,4 @@ Thunder
 ### Egg pattern
 ![image info](../assets/green_nargacuga.png)
 
-Egg Tags: 
+Egg Tags: green,yellow

--- a/docs/monsters/grimclaw_tigrex.md
+++ b/docs/monsters/grimclaw_tigrex.md
@@ -17,4 +17,4 @@ Thunder
 ### Egg pattern
 ![image info](../assets/grimclaw_tigrex.png)
 
-Egg Tags: 
+Egg Tags: orange,blue

--- a/docs/monsters/gypceros.md
+++ b/docs/monsters/gypceros.md
@@ -16,4 +16,4 @@ Fire
 ### Egg pattern
 ![image info](../assets/gypceros.png)
 
-Egg Tags: 
+Egg Tags: blue,pink

--- a/docs/monsters/hellblade_glavenus.md
+++ b/docs/monsters/hellblade_glavenus.md
@@ -18,4 +18,4 @@ Water
 ### Egg pattern
 ![image info](../assets/hellblade_glavenus.png)
 
-Egg Tags: 
+Egg Tags: black,red

--- a/docs/monsters/iodrome.md
+++ b/docs/monsters/iodrome.md
@@ -13,4 +13,4 @@ Water
 ### Egg pattern
 ![image info](../assets/iodrome.png)
 
-Egg Tags: 
+Egg Tags: orange,purple

--- a/docs/monsters/ivory_lagiacrus.md
+++ b/docs/monsters/ivory_lagiacrus.md
@@ -17,4 +17,4 @@ Dragon
 ### Egg pattern
 ![image info](../assets/ivory_lagiacrus.png)
 
-Egg Tags: 
+Egg Tags: blue,yellow

--- a/docs/monsters/jade_barroth.md
+++ b/docs/monsters/jade_barroth.md
@@ -17,4 +17,4 @@ Thunder
 ### Egg pattern
 ![image info](../assets/jade_barroth.png)
 
-Egg Tags: 
+Egg Tags: blue,teal

--- a/docs/monsters/kecha_wacha.md
+++ b/docs/monsters/kecha_wacha.md
@@ -16,4 +16,4 @@ Fire
 ### Egg pattern
 ![image info](../assets/kecha_wacha.png)
 
-Egg Tags: 
+Egg Tags: red,yellow

--- a/docs/monsters/khezu.md
+++ b/docs/monsters/khezu.md
@@ -16,4 +16,4 @@ Fire
 ### Egg pattern
 ![image info](../assets/khezu.png)
 
-Egg Tags: 
+Egg Tags: pink,blue

--- a/docs/monsters/kirin.md
+++ b/docs/monsters/kirin.md
@@ -17,4 +17,4 @@ Fire
 ### Egg pattern
 ![image info](../assets/kirin.png)
 
-Egg Tags: 
+Egg Tags: white,blue

--- a/docs/monsters/kulu-ya-ku.md
+++ b/docs/monsters/kulu-ya-ku.md
@@ -16,4 +16,4 @@ Water
 ### Egg pattern
 ![image info](../assets/kulu-ya-ku.png)
 
-Egg Tags: 
+Egg Tags: orange,cream

--- a/docs/monsters/kushala_daora.md
+++ b/docs/monsters/kushala_daora.md
@@ -20,4 +20,4 @@ Thunder
 ### Egg pattern
 ![image info](../assets/kushala_daora.png)
 
-Egg Tags: 
+Egg Tags: orange,black

--- a/docs/monsters/lagiacrus.md
+++ b/docs/monsters/lagiacrus.md
@@ -17,4 +17,4 @@ Fire
 ### Egg pattern
 ![image info](../assets/lagiacrus.png)
 
-Egg Tags: 
+Egg Tags: blue,red

--- a/docs/monsters/lagombi.md
+++ b/docs/monsters/lagombi.md
@@ -16,4 +16,4 @@ Fire
 ### Egg pattern
 ![image info](../assets/lagombi.png)
 
-Egg Tags: 
+Egg Tags: cream,purple

--- a/docs/monsters/legiana.md
+++ b/docs/monsters/legiana.md
@@ -17,4 +17,4 @@ Thunder
 ### Egg pattern
 ![image info](../assets/legiana.png)
 
-Egg Tags: 
+Egg Tags: white,blue,cream

--- a/docs/monsters/mizutsune.md
+++ b/docs/monsters/mizutsune.md
@@ -18,4 +18,4 @@ Thunder
 ### Egg pattern
 ![image info](../assets/mizutsune.png)
 
-Egg Tags: 
+Egg Tags: white,cream,pink

--- a/docs/monsters/monoblos.md
+++ b/docs/monsters/monoblos.md
@@ -16,4 +16,4 @@ Thunder
 ### Egg pattern
 ![image info](../assets/monoblos.png)
 
-Egg Tags: 
+Egg Tags: orange,red

--- a/docs/monsters/nargacuga.md
+++ b/docs/monsters/nargacuga.md
@@ -16,4 +16,4 @@ Thunder
 ### Egg pattern
 ![image info](../assets/nargacuga.png)
 
-Egg Tags: 
+Egg Tags: blue,purple

--- a/docs/monsters/nergigante.md
+++ b/docs/monsters/nergigante.md
@@ -20,4 +20,4 @@ Thunder
 ### Egg pattern
 ![image info](../assets/nergigante.png)
 
-Egg Tags: 
+Egg Tags: orange,black

--- a/docs/monsters/nerscylla.md
+++ b/docs/monsters/nerscylla.md
@@ -16,4 +16,4 @@ Fire
 ### Egg pattern
 ![image info](../assets/nerscylla.png)
 
-Egg Tags: 
+Egg Tags: orange,purple

--- a/docs/monsters/paolumu.md
+++ b/docs/monsters/paolumu.md
@@ -16,4 +16,4 @@ Fire
 ### Egg pattern
 ![image info](../assets/paolumu.png)
 
-Egg Tags: 
+Egg Tags: cream,white

--- a/docs/monsters/pukei-pukei.md
+++ b/docs/monsters/pukei-pukei.md
@@ -16,4 +16,4 @@ Thunder
 ### Egg pattern
 ![image info](../assets/pukei-pukei.png)
 
-Egg Tags: 
+Egg Tags: cream,green

--- a/docs/monsters/purple_gypceros.md
+++ b/docs/monsters/purple_gypceros.md
@@ -16,4 +16,4 @@ Fire
 ### Egg pattern
 ![image info](../assets/purple_gypceros.png)
 
-Egg Tags: 
+Egg Tags: purple,green

--- a/docs/monsters/purple_ludroth.md
+++ b/docs/monsters/purple_ludroth.md
@@ -16,4 +16,4 @@ Fire
 ### Egg pattern
 ![image info](../assets/purple_ludroth.png)
 
-Egg Tags: 
+Egg Tags: purple,pink

--- a/docs/monsters/qurupeco.md
+++ b/docs/monsters/qurupeco.md
@@ -16,4 +16,4 @@ Ice
 ### Egg pattern
 ![image info](../assets/qurupeco.png)
 
-Egg Tags: 
+Egg Tags: green,purple

--- a/docs/monsters/rajang.md
+++ b/docs/monsters/rajang.md
@@ -23,4 +23,4 @@ Ice
 ### Egg pattern
 ![image info](../assets/rajang.png)
 
-Egg Tags: 
+Egg Tags: brown

--- a/docs/monsters/rathalos.md
+++ b/docs/monsters/rathalos.md
@@ -16,4 +16,4 @@ Thunder
 ### Egg pattern
 ![image info](../assets/rathalos.png)
 
-Egg Tags: 
+Egg Tags: red,blue

--- a/docs/monsters/rathian.md
+++ b/docs/monsters/rathian.md
@@ -16,4 +16,4 @@ Dragon
 ### Egg pattern
 ![image info](../assets/rathian.png)
 
-Egg Tags: 
+Egg Tags: cream,green

--- a/docs/monsters/red_khezu.md
+++ b/docs/monsters/red_khezu.md
@@ -17,4 +17,4 @@ Water
 ### Egg pattern
 ![image info](../assets/red_khezu.png)
 
-Egg Tags: 
+Egg Tags: red,cream

--- a/docs/monsters/royal_ludroth.md
+++ b/docs/monsters/royal_ludroth.md
@@ -16,4 +16,4 @@ Fire
 ### Egg pattern
 ![image info](../assets/royal_ludroth.png)
 
-Egg Tags: 
+Egg Tags: green,yellow

--- a/docs/monsters/ruby_basarios.md
+++ b/docs/monsters/ruby_basarios.md
@@ -16,4 +16,4 @@ Ice
 ### Egg pattern
 ![image info](../assets/ruby_basarios.png)
 
-Egg Tags: 
+Egg Tags: green,pink

--- a/docs/monsters/sand_barioth.md
+++ b/docs/monsters/sand_barioth.md
@@ -16,4 +16,4 @@ Ice
 ### Egg pattern
 ![image info](../assets/sand_barioth.png)
 
-Egg Tags: 
+Egg Tags: orange,pink

--- a/docs/monsters/seregios.md
+++ b/docs/monsters/seregios.md
@@ -16,4 +16,4 @@ Thunder
 ### Egg pattern
 ![image info](../assets/seregios.png)
 
-Egg Tags: 
+Egg Tags: red,yellow

--- a/docs/monsters/shrouded_nerscylla.md
+++ b/docs/monsters/shrouded_nerscylla.md
@@ -16,4 +16,4 @@ Ice
 ### Egg pattern
 ![image info](../assets/shrouded_nerscylla.png)
 
-Egg Tags: 
+Egg Tags: white,yellow

--- a/docs/monsters/silverwind_nargacuga.md
+++ b/docs/monsters/silverwind_nargacuga.md
@@ -16,4 +16,4 @@ Thunder
 ### Egg pattern
 ![image info](../assets/silverwind_nargacuga.png)
 
-Egg Tags: 
+Egg Tags: white,blue

--- a/docs/monsters/stygian_zinogre.md
+++ b/docs/monsters/stygian_zinogre.md
@@ -16,4 +16,4 @@ Thunder
 ### Egg pattern
 ![image info](../assets/stygian_zinogre.png)
 
-Egg Tags: 
+Egg Tags: white,purple

--- a/docs/monsters/teostra.md
+++ b/docs/monsters/teostra.md
@@ -20,4 +20,4 @@ Water
 ### Egg pattern
 ![image info](../assets/teostra.png)
 
-Egg Tags: 
+Egg Tags: red,blue

--- a/docs/monsters/thunderlord_zinogre.md
+++ b/docs/monsters/thunderlord_zinogre.md
@@ -16,4 +16,4 @@ Ice
 ### Egg pattern
 ![image info](../assets/thunderlord_zinogre.png)
 
-Egg Tags: 
+Egg Tags: green,orange

--- a/docs/monsters/tigrex.md
+++ b/docs/monsters/tigrex.md
@@ -16,4 +16,4 @@ Thunder
 ### Egg pattern
 ![image info](../assets/tigrex.png)
 
-Egg Tags: 
+Egg Tags: blue,orange

--- a/docs/monsters/tobi-kadachi.md
+++ b/docs/monsters/tobi-kadachi.md
@@ -17,4 +17,4 @@ Water
 ### Egg pattern
 ![image info](../assets/tobi-kadachi.png)
 
-Egg Tags: 
+Egg Tags: blue,black

--- a/docs/monsters/uragaan.md
+++ b/docs/monsters/uragaan.md
@@ -16,4 +16,4 @@ Water
 ### Egg pattern
 ![image info](../assets/uragaan.png)
 
-Egg Tags: 
+Egg Tags: yellow,brown

--- a/docs/monsters/velkhana.md
+++ b/docs/monsters/velkhana.md
@@ -17,4 +17,4 @@ Fire
 ### Egg pattern
 ![image info](../assets/velkhana.png)
 
-Egg Tags: 
+Egg Tags: blue,white

--- a/docs/monsters/velocidrome.md
+++ b/docs/monsters/velocidrome.md
@@ -16,4 +16,4 @@ Ice
 ### Egg pattern
 ![image info](../assets/velocidrome.png)
 
-Egg Tags: 
+Egg Tags: blue,orange

--- a/docs/monsters/white_monoblos.md
+++ b/docs/monsters/white_monoblos.md
@@ -16,4 +16,4 @@ Ice
 ### Egg pattern
 ![image info](../assets/white_monoblos.png)
 
-Egg Tags: 
+Egg Tags: cream,brown

--- a/docs/monsters/yian_garuga.md
+++ b/docs/monsters/yian_garuga.md
@@ -16,4 +16,4 @@ Water
 ### Egg pattern
 ![image info](../assets/yian_garuga.png)
 
-Egg Tags: 
+Egg Tags: blue,pink

--- a/docs/monsters/yian_kut-ku.md
+++ b/docs/monsters/yian_kut-ku.md
@@ -16,4 +16,4 @@ Ice
 ### Egg pattern
 ![image info](../assets/yian_kut-ku.png)
 
-Egg Tags: 
+Egg Tags: pink,blue

--- a/docs/monsters/zamtrios.md
+++ b/docs/monsters/zamtrios.md
@@ -17,4 +17,4 @@ Thunder
 ### Egg pattern
 ![image info](../assets/zamtrios.png)
 
-Egg Tags: 
+Egg Tags: blue,orange

--- a/docs/monsters/zinogre.md
+++ b/docs/monsters/zinogre.md
@@ -17,4 +17,4 @@ Ice
 ### Egg pattern
 ![image info](../assets/zinogre.png)
 
-Egg Tags: 
+Egg Tags: blue,yellow


### PR DESCRIPTION
Resolves #1 

Added colour tags for all Monstie eggs.

Available colours: (will be noted separately on the site)
- white
- black
- grey
- brown
- red
- blue
- yellow
- green
- purple
- orange
- pink
- teal
- cream